### PR TITLE
add 'createToHost' ftn.

### DIFF
--- a/Native/WebSocket.js
+++ b/Native/WebSocket.js
@@ -10,6 +10,23 @@ Elm.Native.WebSocket.make = function(localRuntime) {
   var Task = Elm.Native.Task.make(localRuntime);
   var Utils = Elm.Native.Utils.make(localRuntime);
 
+  function createToHost(port) {
+    var socket = window.socket;
+    var url = "ws://".concat(window.location.hostname).concat(":");
+    url = url.concat(port);
+    return Task.asyncFunction(function(callback) {
+      if (typeof socket === 'undefined') {
+        socket = new WebSocket(url);
+        socket.onopen = function() {
+          callback(Task.succeed(socket));
+        }
+        window.socket = socket;
+      } else {
+        callback(Task.succeed(socket));
+      }
+    });
+  }
+
   function create(url) {
     var socket = window.socket;
     return Task.asyncFunction(function(callback) {
@@ -63,6 +80,7 @@ Elm.Native.WebSocket.make = function(localRuntime) {
   }
 
   localRuntime.Native.WebSocket.values = {
+    createToHost: createToHost,
     create: create,
     listen: F2(listen),
     send: F2(send),

--- a/WebSocket.elm
+++ b/WebSocket.elm
@@ -5,6 +5,10 @@ import Native.WebSocket
 
 type WebSocket = WebSocket
 
+createToHost : String -> Task x WebSocket
+createToHost =
+  Native.WebSocket.createToHost
+
 create : String -> Task x WebSocket
 create =
   Native.WebSocket.create


### PR DESCRIPTION
since getting the hostname is a huge pain, apparently, here's a function that connects using the port.  So if the url was http://localhost:8000, you can call:

socket = WebSocket.createToHost "1234"

Which is equivalent to this, except without knowing the hostname.  

-- socket = WebSocket.create "ws://localhost:1234"

Anyway there you go!  Handy, but hacky.  Am using it in my project for the nonce.  